### PR TITLE
Hide the implementation class Partial

### DIFF
--- a/src/YoloDev.PartialJson/IPartial.cs
+++ b/src/YoloDev.PartialJson/IPartial.cs
@@ -1,3 +1,4 @@
+using Newtonsoft.Json;
 using System;
 using System.Collections.Immutable;
 using System.Linq.Expressions;
@@ -17,6 +18,7 @@ namespace YoloDev.PartialJson
     IImmutableDictionary<string, object> GetUpdates(Func<PropertyInfo, string> nameConverter);
   }
 
+  [JsonConverter(typeof(PartialConverter))]
   public interface IPartial<T> : IPartial
   {
     new T Proxy { get; }

--- a/test/YoloDev.PartialJson.Test/PartialTest.cs
+++ b/test/YoloDev.PartialJson.Test/PartialTest.cs
@@ -23,7 +23,7 @@ namespace YoloDev.PartialJson.Test
     public void Test()
     {
       var json = "{\"Foo\":\"testing\",\"Bar\":42}";
-      var partialResponse = JsonConvert.DeserializeObject<Partial<TestData>>(json);
+      var partialResponse = JsonConvert.DeserializeObject<IPartial<TestData>>(json);
 
       var proxy = AssertIs<IPartialProxy>(partialResponse.Proxy);
       var partial = proxy.Partial;


### PR DESCRIPTION
Make the interface `IPartial` and `IPartial<T>` the ways to use partials.